### PR TITLE
Project options set in file, fixed object export to be nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Test Action](https://github.com/schul-cloud/commons/workflows/Node%20CI/badge.svg)](https://github.com/schul-cloud/commons/actions)
 [![Deployment Action](https://github.com/schul-cloud/commons/workflows/Build%20and%20Publish/badge.svg)](https://github.com/schul-cloud/commons/actions)
 
-
 <!--
 [![Build Status][travis-image]][travis-url]
 [![Dependency Status][daviddm-image]][daviddm-url]
@@ -37,42 +36,47 @@ To enable multiple inherited objects when parsing environment variables there ma
 ### Sample
 
 ```javascript
-// Access Configuration as Singleton
-import config from '@schul-cloud/commons'
+// Access Configuration as Singleton, using default export (1)
+import config from "@schul-cloud/commons";
 
-// Access configuration as class
-import { Configuration } from '@schul-cloud/commons'
-const config = new Configuration()
+// Access configuration as class (2)
+import { Configuration } from "@schul-cloud/commons";
+const config = new Configuration();
 
-// Initialization must be executed exactly once per instance
-config.init(options)
+// Initialization must be executed exactly once per instance (2)
+config.init(options);
 
-// Then you may run 
-config.has('key')
-config.get('key')
-config.set('key', 'value')
+// Initialization in (1) is done on first access
+
+// Then you may run
+config.has("key");
+config.get("key");
+config.set("key", "value");
 ```
 
 ### Options
 
-| Option&nbsp;key | Value(s)&nbsp;or&nbsp;Type | default | Description |
-|----------------|-----------------------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| logger | any | console | a logger instance |
-| throwOnError | boolean | true | enable throwing an error when an undefined configuration value is requested |
-| notFoundValue | any | null | if throwOnError is not set true, an alternate default value may returned |
-| configDir | string | config | directory where schema and configuration files are located |
-| schemaFileName | string | default.schema.json | default schema file name |
-| baseDir | string | process.cwd() | path to folder where configDir is located |
-| ajvOptions | object | removeAdditional:&nbsp;'all' <br>useDefaults:&nbsp;true <br>coerceTypes:&nbsp;'array' | Schema Parser Options, see https://github.com/epoberezkin/ajv#options |
-| useDotNotation | boolean | true | enables dot notation for parsing environment variables (not json files!) and exporting the current config using has, get, and toObject. |
-| fileEncoding | string | 'utf8' | set file encoding for imported schema and configuration files  |
+| Option&nbsp;key | Value(s)&nbsp;or&nbsp;Type | default                                                                               | Description                                                                                                                             |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| logger          | any                        | console                                                                               | a logger instance                                                                                                                       |
+| throwOnError    | boolean                    | true                                                                                  | enable throwing an error when an undefined configuration value is requested                                                             |
+| notFoundValue   | any                        | null                                                                                  | if throwOnError is not set true, an alternate default value may returned                                                                |
+| configDir       | string                     | config                                                                                | directory where schema and configuration files are located                                                                              |
+| schemaFileName  | string                     | default.schema.json                                                                   | default schema file name                                                                                                                |
+| baseDir         | string                     | process.cwd()                                                                         | path to folder where configDir is located                                                                                               |
+| ajvOptions      | object                     | removeAdditional:&nbsp;'all' <br>useDefaults:&nbsp;true <br>coerceTypes:&nbsp;'array' | Schema Parser Options, see https://github.com/epoberezkin/ajv#options                                                                   |
+| useDotNotation  | boolean                    | true                                                                                  | enables dot notation for parsing environment variables (not json files!) and exporting the current config using has, get, and toObject. |
+| fileEncoding    | string                     | 'utf8'                                                                                | set file encoding for imported schema and configuration files                                                                           |
 
+#### Set options in singleton mode
+
+Create a local file `sc-config.json` in your project root, it will be used on initialization to override default options. The file content must match `IConfigOptions` interface.
 
 ## JSON Schema
 
 ### Enhanced validation
 
-Custom validation keywords may be added to get detailed error messages for specific checks: 
+Custom validation keywords may be added to get detailed error messages for specific checks:
 https://medium.com/@moshfeu/test-json-schema-with-ajv-and-jest-c1d2984234c9
 
 ## Changelog

--- a/sc-config.json
+++ b/sc-config.json
@@ -1,0 +1,4 @@
+{
+	"configDir": "test/data",
+	"dotNotationSeparator": "->"
+}

--- a/test/configuration/index.test.ts
+++ b/test/configuration/index.test.ts
@@ -200,7 +200,7 @@ describe('test configuration', () => {
 
 	});
 
-	describe.only('project customized option file', () => {
+	describe('project customized option file', () => {
 		it('custom dot notation', () => {
 			const helloWorld = 'Hello World!';
 			ConfigurationSingleton.set('Foo->Bar', helloWorld);

--- a/test/configuration/index.test.ts
+++ b/test/configuration/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import dot from 'dot-object';
 
-import DefaultConfiguration, { Configuration, defaultOptions } from '../../src/configuration';
+import ConfigurationSingleton, { Configuration, defaultOptions } from '../../src/configuration';
 import { IConfigOptions } from '../../src/interfaces/IConfigOptions';
 
 describe('test configuration', () => {
@@ -200,10 +200,22 @@ describe('test configuration', () => {
 
 	});
 
+	describe.only('project customized option file', () => {
+		it('custom dot notation', () => {
+			const helloWorld = 'Hello World!';
+			ConfigurationSingleton.set('Foo->Bar', helloWorld);
+			expect(ConfigurationSingleton.get('Foo->Bar')).to.be.equal(helloWorld);
+			const currentConfig = ConfigurationSingleton.toObject();
+			expect(currentConfig.Foo).to.exist;
+			expect(currentConfig.Foo.Bar).to.exist;
+			expect(currentConfig.Foo.Bar).to.be.not.empty;
+			expect(currentConfig.Foo.Bar).to.be.equal(helloWorld);
+		});
+	});
+
 	describe('singleton', () => {
 
-		const config = DefaultConfiguration;
-		config.init(options);
+		const config = ConfigurationSingleton;
 
 		it('get Instance returns same instance on multiple calls', () => {
 			const otherConfig = Configuration.Instance;

--- a/test/data/default.schema.json
+++ b/test/data/default.schema.json
@@ -35,6 +35,15 @@
 				"warning",
 				"error"
 			]
+		},
+		"Foo": {
+			"type": "object",
+			"description": "sample nested property",
+			"properties": {
+				"Bar": {
+					"type": "string"
+				}
+			}
 		}
 	},
 	"required": [


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the toObject export, instead of nested items with separator in name, the object will be exported with nested objects.

The project can be imported and will initialize a default singleton by itself. Using a config file in project root the default options may be overridden.

