### PR TITLE
Sc 3694 reset option added

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "workbench.colorCustomizations": {
     "activityBar.background": "#d04649",
+    "activityBar.activeBackground": "#d04649",
     "activityBar.activeBorder": "#37cb34",
     "activityBar.foreground": "#e7e7e7",
     "activityBar.inactiveForeground": "#e7e7e799",

--- a/README.md
+++ b/README.md
@@ -44,26 +44,32 @@ To enable multiple inherited objects when parsing environment variables there ma
 
 ### Sample
 
-```javascript
-// Access Configuration as Singleton, using default export
-// Initialization is done on first access
-// uses IConfigOptions optionally defined in a sc-config.json file
-import { Configuration as config } from "@schul-cloud/commons";
+    ``` javascript
+    // Access Configuration as Singleton, using default export
+    // Initialization is done on first access
+    // uses IConfigOptions optionally defined in a sc-config.json file
+    import { Configuration as config } from "@schul-cloud/commons";
 
-// Access configuration as class
-// IConfigOptions can be set in constructor options
-import { TestConfiguration } from "@schul-cloud/commons";
-const config = new TestConfiguration(options);
+    // Access configuration as class
+    // IConfigOptions can be set in constructor options
+    import { TestConfiguration } from "@schul-cloud/commons";
+    const config = new TestConfiguration(options);
 
-// Then you may run...
-config.has("key");
-config.toObject();
-// and when the property key has been defined in the schema...
-config.get("key");
-config.set("key", "value");
-// or updating multiple entries
-config.update({...});
-```
+    // Then you may run...
+    config.has("key");
+    const before = config.toObject();
+    // and when the property key has been defined in the schema...
+    config.get("key");
+    config.set("key", "value");
+    // or updating multiple entries
+    config.update({...});
+
+    // suggested for testing only
+    config.remove("key"); // removes a single key
+    config.remove("key", "key2", ...); // remove multiple keys
+    // override the complete config (removes prior values)
+    config.reset(before);
+    ```
 
 ### Options
 

--- a/src/interfaces/IConfigOptions.ts
+++ b/src/interfaces/IConfigOptions.ts
@@ -1,29 +1,29 @@
 export interface IConfigOptions {
 	/**
-   * set a custom logger
-   *
-   * @type {*}
-   * @memberof IConfigOptions
-   */
+	* set a custom logger
+	*
+	* @type {*}
+	* @memberof IConfigOptions
+	*/
 	logger?: any;
 	/**
-   * throw an error when an undefined value is requested
-   *
-   * @type {boolean}
-   * @memberof IConfigOptions
-   */
+	* throw an error when an undefined value is requested
+	*
+	* @type {boolean}
+	* @memberof IConfigOptions
+	*/
 	throwOnError?: boolean;
 	/**
-   * If throwOnUndefined is not true, the default return value which is null may be overriden using this property.
-   *
-   * @type {*}
-   * @memberof IConfigOptions
-   */
+	* If throwOnUndefined is not true, the default return value which is null may be overriden using this property.
+	*
+	* @type {*}
+	* @memberof IConfigOptions
+	*/
 	notFoundValue?: any;
 	configDir?: string;
 	/**
-   * enables debugging output for dotenv
-   */
+	* enables debugging output for dotenv
+	*/
 	debug?: boolean;
 	envDir?: string;
 	baseDir?: string;

--- a/src/interfaces/IConfiguration.ts
+++ b/src/interfaces/IConfiguration.ts
@@ -3,6 +3,7 @@ import { IConfig } from './IConfig';
 export interface IConfiguration {
 	get(key: string): any;
 	update(params: IConfig): boolean;
+	reset(params: IConfig): boolean;
 	set(key: string, value: any): boolean;
 	has(key: string): boolean;
 	toObject(): any;

--- a/src/interfaces/IConfiguration.ts
+++ b/src/interfaces/IConfiguration.ts
@@ -5,6 +5,7 @@ export interface IConfiguration {
 	update(params: IConfig): boolean;
 	reset(params: IConfig): boolean;
 	set(key: string, value: any): boolean;
+	remove(...keys: [string]): boolean;
 	has(key: string): boolean;
 	toObject(): any;
 }

--- a/src/interfaces/IUpdateOptions.ts
+++ b/src/interfaces/IUpdateOptions.ts
@@ -1,0 +1,6 @@
+export interface IUpdateOptions {
+	/**
+	 * instead of regular merge, replace the current configuration with the given properties only.
+	 */
+	reset?: boolean;
+}

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -307,4 +307,53 @@ describe('test configuration', () => {
 		});
 	});
 
+	describe.only('remove single keys from konfiguration', () => {
+		it('remove single manually added key', () => {
+			const config = new Configuration({
+				schemaFileName: 'default.schema.json',
+				configDir: 'test/data'
+			});
+			config.set('String', 'sample');
+			const before = config.toObject();
+			expect(config.get('String')).to.be.equal('sample');
+			expect(config.remove('String')).to.be.equal(true);
+			expect(() => config.get('String')).to.throw;
+			expect('String' in config.toObject()).to.be.false;
+			delete before.String;
+			expect(before).to.deep.equal(config.toObject());
+		});
+
+		it('remove multiple keys', () => {
+			const config = new Configuration({
+				schemaFileName: 'default.schema.json',
+				configDir: 'test/data'
+			});
+			config.set('String', 'sample');
+			config.set('Boolean', 'true');
+			const before = config.toObject();
+			expect(config.get('String')).to.be.equal('sample');
+			expect(config.get('Boolean')).to.be.equal(true);
+			expect(config.remove('String', 'Boolean')).to.be.equal(true);
+			expect(() => config.get('String')).to.throw;
+			expect(() => config.get('Boolean')).to.throw;
+			expect('String' in config.toObject()).to.be.false;
+			expect('Boolean' in config.toObject()).to.be.false;
+			delete before.String;
+			delete before.Boolean;
+			expect(before).to.deep.equal(config.toObject());
+		});
+		it('remove required key fails', () => {
+			const config = new Configuration({
+				schemaFileName: 'default.schema.json',
+				configDir: 'test/data'
+			});
+			config.set('Domain', 'sample.de');
+			const before = config.toObject();
+			expect(config.get('Domain')).to.be.equal('sample.de');
+			expect(() => config.remove('Domain')).to.throw;
+			expect('Domain' in config.toObject()).to.be.true;
+			expect(before).to.deep.equal(config.toObject());
+		});
+	});
+
 });

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -277,7 +277,7 @@ describe('test configuration', () => {
 		});
 	});
 
-	describe(' configuration reset', () => {
+	describe('configuration reset', () => {
 		it('should reset given values', () => {
 			const config = new Configuration({
 				schemaFileName: 'default.schema.json',

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -277,4 +277,34 @@ describe('test configuration', () => {
 		});
 	});
 
+	describe(' configuration reset', () => {
+		it('should reset given values', () => {
+			const config = new Configuration({
+				schemaFileName: 'default.schema.json',
+				configDir: 'test/data'
+			});
+			const before = config.toObject();
+			expect(Object.keys(before).length).to.be.equal(7);
+			expect(before['Domain']).to.be.equal('localhost');
+			config.set('Domain', 'otherdomain.tld');
+			expect(config.get('Domain')).to.be.equal('otherdomain.tld');
+			config.reset(before);
+			expect(config.get('Domain')).to.be.equal('localhost');
+		});
+		it('should remove values not set before', () => {
+			const config = new Configuration({
+				schemaFileName: 'default.schema.json',
+				configDir: 'test/data'
+			});
+			const before = config.toObject();
+			expect(Object.keys(before).length).to.be.equal(7);
+			expect('String' in before).to.be.false;
+			expect(() => config.get('String')).to.throw;
+			config.set('String', 'newValueNotDefinedBefore');
+			expect(config.get('String')).to.be.equal('newValueNotDefinedBefore');
+			config.reset(before);
+			expect(() => config.get('String')).to.throw;
+		});
+	});
+
 });

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -307,7 +307,7 @@ describe('test configuration', () => {
 		});
 	});
 
-	describe.only('remove single keys from konfiguration', () => {
+	describe('remove single keys from konfiguration', () => {
 		it('remove single manually added key', () => {
 			const config = new Configuration({
 				schemaFileName: 'default.schema.json',


### PR DESCRIPTION
#### What does this PR do?

this pr adds the method reset(params) to Configuration instance.
while update(params) only updates the values defined in params, using reset, the config will be reset to have the values in params defined only.
this is required to reset/cleanup the configuration after tests in server