### PR TITLE
Feature: allow to specify dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ coverage/**
 .nyc_output/**
 .vscode/**
 !.vscode/launch.json
+.idea
+*.iml
 
 # added in git, but eslint should ignore this
 tsconfig-lint.json

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ default.schema.json
 ```json
 {
     "title": "Example Schema with dependency",
-	"description": "This schema declares a dependency between two properties.",
-	"additionalProperties": false,
+    "description": "This schema declares a dependency between two properties.",
+    "additionalProperties": false,
     "type": "object",
     "properties": {
         "SERVICE_PROPERTY": {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The configuration is build by parsing multiple sources in the following order (L
 
 The default schema parser options
 
-1. remove all options from upper sources not defined in the schema file
+1. remove all options from upper sources if the schema contains the property `"additionalProperties": false`
 2. applying default values
 3. do a [type conversion](https://ajv.js.org/coercion.html) especially for string to type conversion values not defined in the json files (string to X).
 
@@ -44,8 +44,69 @@ Invalid input values will raise an error by default.
 
 To enable multiple inherited objects when parsing environment variables there may be a dot notation be used. When enabled, this gets applied for export, has, and get too. Currently only `__` (double underscore) is supported as separator due to the dependency [dotenv](https://www.npmjs.com/package/dotenv#should-i-have-multiple-env-files) and bad support of `.` (single dot) in many terminals.
 
+#### Specifying Dependencies
+
+Often specific configuration options are required based on the state of other configuration values.
+These dependencies can be defined using the [if/then/else keywords](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#ifthenelse).
+
+In the example below the rule `SERVICE_REQUIRES_OTHER` rule is activated in the `allOf` block.
+The rule itself is defined in the `definitions` block.
+If the property `SERVICE_PROPERTY` is set to `VALUE_OF_SERVICE` we also require that `OTHER_PROPERTY` is set.
+Make sure that a default value is set for `SERVICE_PROPERTY` [to avoid passing undefined to an if keyword](https://github.com/epoberezkin/ajv/issues/913).
+
 ### Sample
 
+default.schema.json
+```json
+{
+    "title": "Example Schema with dependency",
+	"description": "This schema declares a dependency between two properties.",
+	"additionalProperties": false,
+    "type": "object",
+    "properties": {
+        "SERVICE_PROPERTY": {
+            "type": "string",
+            "enum": ["none", "VALUE_OF_SERVICE"],
+            "default": "none"
+        },
+        "OTHER_PROPERTY": {
+            "type": "string"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/SERVICE_REQUIRES_OTHER"
+        }
+    ],
+    "definitions": {
+        "SERVICE_REQUIRES_OTHER": {
+            "if": {
+                "properties": {
+                    "SERVICE_PROPERTY": {
+                        "const": "VALUE_OF_SERVICE"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "OTHER_PROPERTY"
+                ]
+            }
+        }
+    }
+}
+```
+
+default.json
+```json
+{
+    "$schema": "default.schema.json",
+    "SERVICE_PROPERTY": "VALUE_OF_SERVICE",
+    "OTHER_PROPERTY": "VALUE"
+}
+```
+
+index.js
 ```javascript
 // Access Configuration as Singleton, using default export
 // Initialization is done on first access
@@ -75,17 +136,17 @@ config.reset(before);
 
 ### Options
 
-| Option&nbsp;key | Value(s)&nbsp;or&nbsp;Type | default                                                                               | Description                                                                                                                             |
-| --------------- | -------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| logger          | any                        | console                                                                               | a logger instance                                                                                                                       |
-| throwOnError    | boolean                    | true                                                                                  | enable throwing an error when an undefined configuration value is requested                                                             |
-| notFoundValue   | any                        | null                                                                                  | if throwOnError is not set true, an alternate default value may returned                                                                |
-| configDir       | string                     | config                                                                                | directory where schema and configuration files are located                                                                              |
-| schemaFileName  | string                     | default.schema.json                                                                   | default schema file name                                                                                                                |
-| baseDir         | string                     | process.cwd()                                                                         | path to folder where configDir is located                                                                                               |
-| ajvOptions      | object                     | removeAdditional:&nbsp;'all' <br>useDefaults:&nbsp;true <br>coerceTypes:&nbsp;'array' | Schema Parser Options, see https://github.com/epoberezkin/ajv#options                                                                   |
-| useDotNotation  | boolean                    | true                                                                                  | enables dot notation for parsing environment variables (not json files!) and exporting the current config using has, get, and toObject. |
-| fileEncoding    | string                     | 'utf8'                                                                                | set file encoding for imported schema and configuration files                                                                           |
+| Option&nbsp;key | Value(s)&nbsp;or&nbsp;Type | default                                                                                | Description                                                                                                                             |
+| --------------- | -------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| logger          | any                        | console                                                                                | a logger instance                                                                                                                       |
+| throwOnError    | boolean                    | true                                                                                   | enable throwing an error when an undefined configuration value is requested                                                             |
+| notFoundValue   | any                        | null                                                                                   | if throwOnError is not set true, an alternate default value may returned                                                                |
+| configDir       | string                     | config                                                                                 | directory where schema and configuration files are located                                                                              |
+| schemaFileName  | string                     | default.schema.json                                                                    | default schema file name                                                                                                                |
+| baseDir         | string                     | process.cwd()                                                                          | path to folder where configDir is located                                                                                               |
+| ajvOptions      | object                     | removeAdditional:&nbsp;'true' <br>useDefaults:&nbsp;true <br>coerceTypes:&nbsp;'array' | Schema Parser Options, see https://github.com/epoberezkin/ajv#options                                                                   |
+| useDotNotation  | boolean                    | true                                                                                   | enables dot notation for parsing environment variables (not json files!) and exporting the current config using has, get, and toObject. |
+| fileEncoding    | string                     | 'utf8'                                                                                 | set file encoding for imported schema and configuration files                                                                           |
 
 ## JSON Schema
 

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -22,7 +22,7 @@ export const defaultOptions: IRequiredConfigOptions = {
 	schemaFileName: 'default.schema.json',
 	baseDir: process.cwd(),
 	ajvOptions: {
-		removeAdditional: 'all',
+		removeAdditional: true,
 		useDefaults: true,
 		coerceTypes: 'array'
 	},

--- a/src/interfaces/IConfigOptions.ts
+++ b/src/interfaces/IConfigOptions.ts
@@ -1,3 +1,5 @@
+import { Options } from 'Ajv';
+
 export interface IConfigOptions {
 	/**
 	* set a custom logger
@@ -25,6 +27,7 @@ export interface IConfigOptions {
 	* enables debugging output for dotenv
 	*/
 	debug?: boolean;
+	ajvOptions?: Options;
 	envDir?: string;
 	baseDir?: string;
 	schemaFileName?: string;

--- a/src/interfaces/IConfigOptions.ts
+++ b/src/interfaces/IConfigOptions.ts
@@ -1,4 +1,4 @@
-import { Options } from 'Ajv';
+import Ajv from 'ajv';
 
 export interface IConfigOptions {
 	/**
@@ -27,7 +27,7 @@ export interface IConfigOptions {
 	* enables debugging output for dotenv
 	*/
 	debug?: boolean;
-	ajvOptions?: Options;
+	ajvOptions?: Ajv.Options;
 	envDir?: string;
 	baseDir?: string;
 	schemaFileName?: string;

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -261,7 +261,7 @@ describe('test configuration', () => {
 		it('property-value based dependency (feature-flag condition)', () => {
 			const config = new Configuration({
 				schemaFileName: 'dependencies.schema.json',
-				configDir: 'test/data'
+				configDir: 'test/data',
 			});
 
 			expect(config.get('FEATURE_FLAG')).to.be.false;
@@ -356,4 +356,268 @@ describe('test configuration', () => {
 		});
 	});
 
+	describe('ajv', () => {
+		const Ajv = require('ajv');
+		const ajv = new Ajv({
+			removeAdditional: true,
+			useDefaults: true,
+			coerceTypes: 'array'
+		});
+
+		describe('if/then', () => {
+			const schema = {
+				"title": "dependency test schema",
+				"type": "object",
+				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"properties": {
+					"FEATURE_FLAG": {
+						"type": "boolean",
+						"default": false
+					},
+					"FEATURE_OPTION": {
+						"type": "string",
+						"format": "uri"
+					},
+					"OTHER_FEATURE_OPTION": {
+						"type": "number",
+						"default": 42
+					}
+				},
+				"if": {
+					"properties": {
+						"FEATURE_FLAG": {
+							"const": true
+						}
+					}
+				},
+				"then": {
+					"required": [
+						"FEATURE_OPTION",
+						"OTHER_FEATURE_OPTION"
+					]
+				}
+			};
+			const validate = ajv.compile(schema);
+
+			it('defaults to false', () => {
+				const valid = validate({});
+				expect(valid).to.be.true;
+			});
+
+			it('valid with all options', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"FEATURE_OPTION": "http://asd.de",
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('invalid without option', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.false;
+			});
+
+			it('valid if false', () => {
+				const valid = validate({
+					"FEATURE_FLAG": false,
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('valid with defaults', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"FEATURE_OPTION": "http://asd.de",
+				});
+				expect(valid).to.be.true;
+			});
+		});
+
+		describe('if/then $ref', () => {
+			const schema = {
+				"title": "dependency test schema",
+				"type": "object",
+				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"properties": {
+					"FEATURE_FLAG": {
+						"type": "boolean",
+						"default": false
+					},
+					"FEATURE_OPTION": {
+						"type": "string",
+						"format": "uri"
+					},
+					"OTHER_FEATURE_OPTION": {
+						"type": "number",
+						"default": 42
+					}
+				},
+				"allOf": [
+					{
+						"$ref": "#/definitions/require_feature"
+					}
+				],
+				"definitions": {
+					"require_feature": {
+						"if": {
+							"properties": {
+								"FEATURE_FLAG": {
+									"const": true
+								}
+							}
+						},
+						"then": {
+							"required": [
+								"FEATURE_OPTION",
+								"OTHER_FEATURE_OPTION"
+							]
+						}
+					}
+				}
+			};
+			const validate = ajv.compile(schema);
+
+			it('defaults to false', () => {
+				const valid = validate({});
+				expect(valid).to.be.true;
+			});
+
+			it('valid with all options', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"FEATURE_OPTION": "http://asd.de",
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('invalid without option', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.false;
+			});
+
+			it('valid if false', () => {
+				const valid = validate({
+					"FEATURE_FLAG": false,
+					"OTHER_FEATURE_OPTION": 12
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('valid with defaults', () => {
+				const valid = validate({
+					"FEATURE_FLAG": true,
+					"FEATURE_OPTION": "http://asd.de",
+				});
+				expect(valid).to.be.true;
+			});
+		});
+
+		describe('if/then enum $ref', () => {
+			// good to know: conditional validation is always true when the properties is `undefined`
+			// https://github.com/epoberezkin/ajv/issues/913
+			const schema = {
+				"title": "dependency test schema",
+				"type": "object",
+				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"properties": {
+					"SERVICE": {
+						"type": "string",
+						"enum": ["none", "SERVICE_A", "SERVICE_B"],
+						"default": "none"
+					},
+					"SERVICE_A_URL": {
+						"type": "string",
+						"format": "uri"
+					},
+					"SERVICE_B_URL": {
+						"type": "string",
+						"format": "uri"
+					}
+				},
+				"allOf": [
+					{
+						"$ref": "#/definitions/require_service_a_url",
+					},
+					{
+						"$ref": "#/definitions/require_service_b_url",
+					},
+				],
+				"definitions": {
+					"require_service_a_url": {
+						"if": {
+							"properties": {
+								"SERVICE": {
+									"const": "SERVICE_A"
+								}
+							}
+						},
+						"then": {
+							"required": [
+								"SERVICE_A_URL",
+							]
+						}
+					},
+					"require_service_b_url": {
+						"if": {
+							"properties": {
+								"SERVICE": {
+									"const": "SERVICE_B"
+								}
+							}
+						},
+						"then": {
+							"required": [
+								"SERVICE_B_URL",
+							]
+						}
+					}
+				}
+			};
+			const validate = ajv.compile(schema);
+
+			it('empty defaults to SERVICE_A', () => {
+				const valid = validate({});
+				expect(valid).to.be.true;
+			});
+
+			it('SERVICE_A url valid', () => {
+				const valid = validate({
+					"SERVICE": "SERVICE_A",
+					"SERVICE_A_URL": "http://asd.de",
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('SERVICE_A url missing', () => {
+				const valid = validate({
+					"SERVICE": "SERVICE_A",
+				});
+				expect(valid).to.be.false;
+			});
+
+			it('SERVICE_B url valid', () => {
+				const valid = validate({
+					"SERVICE": "SERVICE_B",
+					"SERVICE_B_URL": "http://asd.de",
+				});
+				expect(valid).to.be.true;
+			});
+
+			it('SERVICE_B url missing', () => {
+				const valid = validate({
+					"SERVICE": "SERVICE_B",
+				});
+				expect(valid).to.be.false;
+			});
+		});
+	});
 });

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -259,6 +259,9 @@ describe('test configuration', () => {
 
 	describe('schema dependencies', () => {
 		it('property-value based dependency (feature-flag condition)', () => {
+			// Specifying dependencies this way does not work when the ajv option {removeAdditional: 'all'} is set,
+			// because it would remove all values which are not mentioned in the if block.
+			// https://github.com/epoberezkin/ajv#filtering-data
 			const config = new Configuration({
 				schemaFileName: 'dependencies.schema.json',
 				configDir: 'test/data',
@@ -369,6 +372,7 @@ describe('test configuration', () => {
 				"title": "dependency test schema",
 				"type": "object",
 				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"additionalProperties": false,
 				"properties": {
 					"FEATURE_FLAG": {
 						"type": "boolean",
@@ -443,6 +447,7 @@ describe('test configuration', () => {
 				"title": "dependency test schema",
 				"type": "object",
 				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"additionalProperties": false,
 				"properties": {
 					"FEATURE_FLAG": {
 						"type": "boolean",
@@ -528,6 +533,7 @@ describe('test configuration', () => {
 				"title": "dependency test schema",
 				"type": "object",
 				"description": "this schema declares different dependency methodologies based on specific values defined",
+				"additionalProperties": false,
 				"properties": {
 					"SERVICE": {
 						"type": "string",

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import dot from 'dot-object';
+import Ajv from 'ajv';
 
 import ConfigurationSingleton, {
 	Configuration,
@@ -360,7 +361,6 @@ describe('test configuration', () => {
 	});
 
 	describe('ajv', () => {
-		const Ajv = require('ajv');
 		const ajv = new Ajv({
 			removeAdditional: true,
 			useDefaults: true,
@@ -369,35 +369,35 @@ describe('test configuration', () => {
 
 		describe('if/then', () => {
 			const schema = {
-				"title": "dependency test schema",
-				"type": "object",
-				"description": "this schema declares different dependency methodologies based on specific values defined",
-				"additionalProperties": false,
-				"properties": {
-					"FEATURE_FLAG": {
-						"type": "boolean",
-						"default": false
+				'title': 'dependency test schema',
+				'type': 'object',
+				'description': 'this schema declares different dependency methodologies based on specific values defined',
+				'additionalProperties': false,
+				'properties': {
+					'FEATURE_FLAG': {
+						'type': 'boolean',
+						'default': false
 					},
-					"FEATURE_OPTION": {
-						"type": "string",
-						"format": "uri"
+					'FEATURE_OPTION': {
+						'type': 'string',
+						'format': 'uri'
 					},
-					"OTHER_FEATURE_OPTION": {
-						"type": "number",
-						"default": 42
+					'OTHER_FEATURE_OPTION': {
+						'type': 'number',
+						'default': 42
 					}
 				},
-				"if": {
-					"properties": {
-						"FEATURE_FLAG": {
-							"const": true
+				'if': {
+					'properties': {
+						'FEATURE_FLAG': {
+							'const': true
 						}
 					}
 				},
-				"then": {
-					"required": [
-						"FEATURE_OPTION",
-						"OTHER_FEATURE_OPTION"
+				'then': {
+					'required': [
+						'FEATURE_OPTION',
+						'OTHER_FEATURE_OPTION'
 					]
 				}
 			};
@@ -410,33 +410,33 @@ describe('test configuration', () => {
 
 			it('valid with all options', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"FEATURE_OPTION": "http://asd.de",
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': true,
+					'FEATURE_OPTION': 'http://asd.de',
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('invalid without option', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': true,
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.false;
 			});
 
 			it('valid if false', () => {
 				const valid = validate({
-					"FEATURE_FLAG": false,
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': false,
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('valid with defaults', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"FEATURE_OPTION": "http://asd.de",
+					'FEATURE_FLAG': true,
+					'FEATURE_OPTION': 'http://asd.de',
 				});
 				expect(valid).to.be.true;
 			});
@@ -444,42 +444,42 @@ describe('test configuration', () => {
 
 		describe('if/then $ref', () => {
 			const schema = {
-				"title": "dependency test schema",
-				"type": "object",
-				"description": "this schema declares different dependency methodologies based on specific values defined",
-				"additionalProperties": false,
-				"properties": {
-					"FEATURE_FLAG": {
-						"type": "boolean",
-						"default": false
+				'title': 'dependency test schema',
+				'type': 'object',
+				'description': 'this schema declares different dependency methodologies based on specific values defined',
+				'additionalProperties': false,
+				'properties': {
+					'FEATURE_FLAG': {
+						'type': 'boolean',
+						'default': false
 					},
-					"FEATURE_OPTION": {
-						"type": "string",
-						"format": "uri"
+					'FEATURE_OPTION': {
+						'type': 'string',
+						'format': 'uri'
 					},
-					"OTHER_FEATURE_OPTION": {
-						"type": "number",
-						"default": 42
+					'OTHER_FEATURE_OPTION': {
+						'type': 'number',
+						'default': 42
 					}
 				},
-				"allOf": [
+				'allOf': [
 					{
-						"$ref": "#/definitions/require_feature"
+						'$ref': '#/definitions/require_feature'
 					}
 				],
-				"definitions": {
-					"require_feature": {
-						"if": {
-							"properties": {
-								"FEATURE_FLAG": {
-									"const": true
+				'definitions': {
+					'require_feature': {
+						'if': {
+							'properties': {
+								'FEATURE_FLAG': {
+									'const': true
 								}
 							}
 						},
-						"then": {
-							"required": [
-								"FEATURE_OPTION",
-								"OTHER_FEATURE_OPTION"
+						'then': {
+							'required': [
+								'FEATURE_OPTION',
+								'OTHER_FEATURE_OPTION'
 							]
 						}
 					}
@@ -494,33 +494,33 @@ describe('test configuration', () => {
 
 			it('valid with all options', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"FEATURE_OPTION": "http://asd.de",
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': true,
+					'FEATURE_OPTION': 'http://asd.de',
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('invalid without option', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': true,
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.false;
 			});
 
 			it('valid if false', () => {
 				const valid = validate({
-					"FEATURE_FLAG": false,
-					"OTHER_FEATURE_OPTION": 12
+					'FEATURE_FLAG': false,
+					'OTHER_FEATURE_OPTION': 12
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('valid with defaults', () => {
 				const valid = validate({
-					"FEATURE_FLAG": true,
-					"FEATURE_OPTION": "http://asd.de",
+					'FEATURE_FLAG': true,
+					'FEATURE_OPTION': 'http://asd.de',
 				});
 				expect(valid).to.be.true;
 			});
@@ -530,59 +530,59 @@ describe('test configuration', () => {
 			// good to know: conditional validation is always true when the properties is `undefined`
 			// https://github.com/epoberezkin/ajv/issues/913
 			const schema = {
-				"title": "dependency test schema",
-				"type": "object",
-				"description": "this schema declares different dependency methodologies based on specific values defined",
-				"additionalProperties": false,
-				"properties": {
-					"SERVICE": {
-						"type": "string",
-						"enum": ["none", "SERVICE_A", "SERVICE_B"],
-						"default": "none"
+				'title': 'dependency test schema',
+				'type': 'object',
+				'description': 'this schema declares different dependency methodologies based on specific values defined',
+				'additionalProperties': false,
+				'properties': {
+					'SERVICE': {
+						'type': 'string',
+						'enum': ['none', 'SERVICE_A', 'SERVICE_B'],
+						'default': 'none'
 					},
-					"SERVICE_A_URL": {
-						"type": "string",
-						"format": "uri"
+					'SERVICE_A_URL': {
+						'type': 'string',
+						'format': 'uri'
 					},
-					"SERVICE_B_URL": {
-						"type": "string",
-						"format": "uri"
+					'SERVICE_B_URL': {
+						'type': 'string',
+						'format': 'uri'
 					}
 				},
-				"allOf": [
+				'allOf': [
 					{
-						"$ref": "#/definitions/require_service_a_url",
+						'$ref': '#/definitions/require_service_a_url',
 					},
 					{
-						"$ref": "#/definitions/require_service_b_url",
+						'$ref': '#/definitions/require_service_b_url',
 					},
 				],
-				"definitions": {
-					"require_service_a_url": {
-						"if": {
-							"properties": {
-								"SERVICE": {
-									"const": "SERVICE_A"
+				'definitions': {
+					'require_service_a_url': {
+						'if': {
+							'properties': {
+								'SERVICE': {
+									'const': 'SERVICE_A'
 								}
 							}
 						},
-						"then": {
-							"required": [
-								"SERVICE_A_URL",
+						'then': {
+							'required': [
+								'SERVICE_A_URL',
 							]
 						}
 					},
-					"require_service_b_url": {
-						"if": {
-							"properties": {
-								"SERVICE": {
-									"const": "SERVICE_B"
+					'require_service_b_url': {
+						'if': {
+							'properties': {
+								'SERVICE': {
+									'const': 'SERVICE_B'
 								}
 							}
 						},
-						"then": {
-							"required": [
-								"SERVICE_B_URL",
+						'then': {
+							'required': [
+								'SERVICE_B_URL',
 							]
 						}
 					}
@@ -597,30 +597,30 @@ describe('test configuration', () => {
 
 			it('SERVICE_A url valid', () => {
 				const valid = validate({
-					"SERVICE": "SERVICE_A",
-					"SERVICE_A_URL": "http://asd.de",
+					'SERVICE': 'SERVICE_A',
+					'SERVICE_A_URL': 'http://asd.de',
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('SERVICE_A url missing', () => {
 				const valid = validate({
-					"SERVICE": "SERVICE_A",
+					'SERVICE': 'SERVICE_A',
 				});
 				expect(valid).to.be.false;
 			});
 
 			it('SERVICE_B url valid', () => {
 				const valid = validate({
-					"SERVICE": "SERVICE_B",
-					"SERVICE_B_URL": "http://asd.de",
+					'SERVICE': 'SERVICE_B',
+					'SERVICE_B_URL': 'http://asd.de',
 				});
 				expect(valid).to.be.true;
 			});
 
 			it('SERVICE_B url missing', () => {
 				const valid = validate({
-					"SERVICE": "SERVICE_B",
+					'SERVICE': 'SERVICE_B',
 				});
 				expect(valid).to.be.false;
 			});

--- a/test/data/default.schema.json
+++ b/test/data/default.schema.json
@@ -1,5 +1,6 @@
 {
 	"type": "object",
+	"additionalProperties": false,
 	"properties": {
 		"ENV_CONFIG": {
 			"type": "string"

--- a/test/data/dependencies.schema.json
+++ b/test/data/dependencies.schema.json
@@ -2,6 +2,7 @@
 	"title": "dependency test schema",
 	"type": "object",
 	"description": "this schema declares different dependency methodologies based on specific values defined",
+	"additionalProperties": false,
 	"properties": {
 		"FEATURE_FLAG": {
 			"type": "boolean",
@@ -21,12 +22,12 @@
 			"FEATURE_FLAG": {
 				"const": true
 			}
-		},
-		"then": {
-			"required": [
-				"FEATURE_OPTION",
-				"OTHER_FEATURE_OPTION"
-			]
 		}
+	},
+	"then": {
+		"required": [
+			"FEATURE_OPTION",
+			"OTHER_FEATURE_OPTION"
+		]
 	}
 }

--- a/test/data/dependencies.schema.json
+++ b/test/data/dependencies.schema.json
@@ -17,17 +17,26 @@
 			"default": 42
 		}
 	},
-	"if": {
-		"properties": {
-			"FEATURE_FLAG": {
-				"const": true
+	"allOf": [
+		{
+			"$ref": "#/definitions/require_feature_options"
+		}
+	],
+	"definitions": {
+		"require_feature_options": {
+			"if": {
+				"properties": {
+					"FEATURE_FLAG": {
+						"const": true
+					}
+				}
+			},
+			"then": {
+				"required": [
+					"FEATURE_OPTION",
+					"OTHER_FEATURE_OPTION"
+				]
 			}
 		}
-	},
-	"then": {
-		"required": [
-			"FEATURE_OPTION",
-			"OTHER_FEATURE_OPTION"
-		]
 	}
 }

--- a/test/data/development.json
+++ b/test/data/development.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "default.schema.json",
 	"ENV_CONFIG": "development",
 	"Domain": "localhost",
 	"Version": "1.2.3",

--- a/test/data/dot.schema.json
+++ b/test/data/dot.schema.json
@@ -1,5 +1,6 @@
 {
 	"type": "object",
+	"additionalProperties": false,
 	"properties": {
 		"Sample": {
 			"type": "string",

--- a/test/data/test.json
+++ b/test/data/test.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "default.schema.json",
 	"ENV_CONFIG": "test",
 	"Boolean": true,
 	"Domain": "localhost",


### PR DESCRIPTION
The syntax of the dependency example in the test and therefore no checks were executed.  `if` and `then` have to be on the same level.
Specifying dependencies this way does not work when the [ajv option](https://github.com/epoberezkin/ajv#options-to-modify-validated-data) `{removeAdditional: 'all'}` is set, because it would remove all values which are not mentioned in the if block. This behaviour is confusing ([read more](https://github.com/epoberezkin/ajv#filtering-data)). 

Therefore I set `removeAdditional: true`, this change requires to set `"additionalProperties": false,` in all schemas to still remove properties which were not defined in the schema.

In addition I extended the tests with more dependency definitions.